### PR TITLE
Snapcode images should now be persisted.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 .byebug_history
 
 /app/assets/images
+*.DS_Store

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -1,6 +1,6 @@
 class DevelopersController < ApplicationController
   def index
-    @developers = Developer.paginate(page: params[:page], per_page: 8)
+    @developers = Developer.paginate(page: params[:page], per_page: 8).order(created_at: :asc)
   end
 
   def new

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -1,6 +1,6 @@
 class DevelopersController < ApplicationController
   def index
-    @developers = Developer.paginate(page: params[:page], per_page: 8).order(created_at: :asc)
+    @developers = Developer.paginate(page: params[:page], per_page: 8).order(id: :asc)
   end
 
   def new

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -12,7 +12,7 @@ class DevelopersController < ApplicationController
 
     respond_to do |format|
       if @developer.save
-        format.html { redirect_to developers_path, notice: '👻 You\'ve been successfully added to our growing list of devs on Snapchat.' }
+        format.html { redirect_to developers_path, notice: 'You\'ve been successfully added to our growing list of devs on Snapchat.' }
       else
         format.html { render :new }
       end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -2,15 +2,19 @@ require 'nokogiri'
 require 'open-uri'
 
 class Developer < ApplicationRecord
-	before_save :get_svg
+	before_save :svg_image
 
   validates :snapchat_username, :full_name, :about, presence: true
   validates :snapchat_username, uniqueness: { message: "is already in this directory."}
   scope :from_newest, -> { order('created_at DESC') }
 
-  private
-	def get_svg
-		image = Nokogiri::XML open("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=#{ self.snapchat_username }&type=SVG")
+  def get_svg_image(url)
+		image = Nokogiri::XML open(url)
 		self.snapcode_image = image.to_html
+	end
+
+  private
+	def svg_image
+		self.get_svg_image("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=#{ self.snapchat_username }&type=SVG")
 	end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -10,7 +10,7 @@ class Developer < ApplicationRecord
 
   private
 	def get_svg
-		download_image = Nokogiri::XML open("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=#{ self.username }&type=SVG")
-		self.snapcode_image = download_image.to_html
+		image = Nokogiri::XML open("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=#{ self.snapchat_username }&type=SVG")
+		self.snapcode_image = image.to_html
 	end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,5 +1,16 @@
+require 'nokogiri'
+require 'open-uri'
+
 class Developer < ApplicationRecord
+	before_save :get_svg
+
   validates :snapchat_username, :full_name, :about, presence: true
   validates :snapchat_username, uniqueness: { message: "is already in this directory."}
   scope :from_newest, -> { order('created_at DESC') }
+
+  private
+	def get_svg
+		download_image = Nokogiri::XML open("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=#{ self.username }&type=SVG")
+		self.snapcode_image = download_image.to_html
+	end
 end

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -28,7 +28,11 @@
               <center><h4 class="blockquote-footer"><%= developer.about %></h4></center>
             </div>
             <center><div class="modal-body">
-              <%= image_tag("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=#{ developer.snapchat_username }&type=PNG") %>
+              <% if developer.snapcode_image? %>
+                <%= render inline: "#{developer.snapcode_image}" %>
+              <% else %>
+                <%= image_tag("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=#{ developer.snapchat_username }&type=PNG") %>
+              <% end %>
               <h2><%= developer.snapchat_username %></h2>
             </div></center>
             <div class="modal-footer">

--- a/db/migrate/20160418211433_add_snapcode_image_to_developers.rb
+++ b/db/migrate/20160418211433_add_snapcode_image_to_developers.rb
@@ -1,0 +1,5 @@
+class AddSnapcodeImageToDevelopers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :developers, :snapcode_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160411072719) do
+ActiveRecord::Schema.define(version: 20160418211433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,8 +20,13 @@ ActiveRecord::Schema.define(version: 20160411072719) do
     t.string   "snapchat_username"
     t.string   "full_name"
     t.text     "about"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.string   "snapcode_file_name"
+    t.string   "snapcode_content_type"
+    t.integer  "snapcode_file_size"
+    t.datetime "snapcode_updated_at"
+    t.string   "snapcode_image"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,19 +1,4 @@
-# encoding: UTF-8
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
-#
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
-#
-# It's strongly recommended that you check this file into your version control system.
-
 ActiveRecord::Schema.define(version: 20160418211433) do
-
-  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "developers", force: :cascade do |t|
@@ -28,5 +13,4 @@ ActiveRecord::Schema.define(version: 20160418211433) do
     t.datetime "snapcode_updated_at"
     t.string   "snapcode_image"
   end
-
 end

--- a/lib/tasks/set_snapcode_image.rake
+++ b/lib/tasks/set_snapcode_image.rake
@@ -7,7 +7,7 @@ namespace :set_snapcode_image do
   	developers_with_no_svg.each do |d|
       svg_image = d.get_svg_image("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=\
           #{ d.snapchat_username }&type=SVG")
-  			d.update(snapcode: svg_image)
+  			d.update(snapcode_image: svg_image)
    		sleep 10
   	end
   end

--- a/lib/tasks/set_snapcode_image.rake
+++ b/lib/tasks/set_snapcode_image.rake
@@ -1,0 +1,14 @@
+namespace :set_snapcode_image do
+	desc "Downloads snapcode images for older members in database"
+
+	task :previous_members => :environment do
+		developers_with_no_svg = Developer.where(snapcode_image: nil)
+
+  	developers_with_no_svg.each do |d|
+      svg_image = d.get_svg_image("https://feelinsonice-hrd.appspot.com/web/deeplink/snapcode?username=\
+          #{ d.snapchat_username }&type=SVG")
+  			d.update(snapcode: svg_image)
+   		sleep 10
+  	end
+  end
+end


### PR DESCRIPTION
Following @paneq's advice we now have snapcodes persisted, so no more queries to Snapchat after the initial request upon registrations. 

I wrote a rake task to fix old members' snapcode images too. Please run 
`rake set_snapcode_image:previous_members` on production to fix this.
Also please don't forget `heroku restart` after migration, just in case.
